### PR TITLE
Don't do 'make all' when running regress (not needed) for OMI

### DIFF
--- a/project.py
+++ b/project.py
@@ -213,7 +213,7 @@ class ProjectOMI(Project):
         self.subProjects = ["omi", "pal"]
         self.makeDependencies = False
         self.projectName = "omi"
-        self.targets = "all tests"
+        self.targets = "clean"  # Do 'make clean' just do something (regress is all inclusive)
         self.postBuildSteps = [ "./regress" ]
 
 class ProjectOMS(Project):


### PR DESCRIPTION
Until OMI can make it's own kits, there's no point in having the "make" step do anything since, in the end, the regress script will rebuild anyway.

@ostc-devs @yakman2020 
