### PR TITLE
add omikits project

### DIFF
--- a/pbuild
+++ b/pbuild
@@ -1,0 +1,207 @@
+#
+# Configuration file for pbuild.  This file is normally stored in ~/.pbuild,
+# but can be customized with environment variable "PBUILD" (full path).
+#
+
+#
+# Default log file location
+# With no customization, you get:  "~/"  (expanded to your home directory)
+#
+# You can customize with lines like the following:
+# logdir: ~/pbuild_logs
+# logdir_prior: ~/pbuild_logs/prior
+#
+# If specified, logdir_prior forms a logfile directory that log files are
+# moved to prior to pbuild starting up.  This allows you to save one level
+# of prior log files from pbuild.
+#
+# Be certain to create the logfile directory prior to running pbuild
+
+logdir: ~/pbuild_logs
+logdir_prior: ~/pbuild_logs/prior
+
+#
+# Default selector to build if unspecified on command line.
+#
+# NOTE: This line must appear before all host entries to be handled properly!
+#
+# You can customize with a line like the following:
+# select: om
+
+select: om
+
+#
+# Systems to exclude in the build:
+# With no customization, you get:  ""
+#
+# You can customize with a line like the following:
+# exclude: sun_5.10_sparc,suse_9_32
+
+#
+# Settings that may be customized:
+# With no cusomization, you get:
+#   "CheckValidity,Debug,DeleteLogfiles,NoDiagnoseErrors,NoLogfileRename,NoLogfileSelect,Progress,SummaryScreen"
+#
+# You can customize with a line like the following:
+#
+# settings: LogfileRename,NoSummaryScreen
+
+settings: NoDiagnoseErrors,NoCheckValidity,LogfileRename,NoSummaryScreen
+
+#
+# Per-project configuration options:
+#   Keyword:Project:value
+#
+# Example: "configure_options : om : --enable-local-omi"
+#
+# Valid keywords:  make_target, configure_options
+
+#
+# Test settings that may be customized:
+# Attributes are controlled with "test_attributes",
+# Test names are controlled with "test_names".
+#
+# With no customization, you get all tests (no restrictions)
+#
+# You can customize with a line like the following:
+#
+# test_attributes: -slow
+# test_names: atomic,condition
+
+#
+# This rest of the file contains lines with three pieces of information per
+# line (space separated):
+#   Optional: "Host:" constant to specify that this is a host entry
+#   Key (name for referring to the entry)
+#   Host name (DNS name or IP address)
+#   Directory path on host
+#   Project (must specify selector to specify project)
+#      Project must be one of:
+#         om (for Operations Manager),
+#         oms (for Operatations Management Suite), or
+#         a host of others (see documentation)
+#   Optional: Select specification (to match with command line and/or default)
+#      If a select entry is specified, you MUST specify a selector to build with
+#      This is useful if you build multiple projects. If you only build one
+#      project, then you need not specify the select specification.
+
+# Operations Manager
+
+host:	aix_6.1		osd16-aix61-01		~/dev/bld-scxcore	om
+host:	aix_7.1		osd16-aix71-01		~/dev/bld-scxcore	om
+host:	hp_v3_ia64	osdevia-hpux31-01	~/dev/bld-scxcore	om
+host:	sun_5.10_sparc	osdevsp-sol10-01	~/dev/bld-scxcore	om
+host:	sun_5.10_x86	osd86-sol10-01		~/dev/bld-scxcore	om
+host:	sun_5.11_sparc	osdevsp-sol11-02	~/dev/bld-scxcore	om
+host:	sun_5.11_x86	osd86-sol11-01		~/dev/bld-scxcore	om
+host:	rhel_7.1_ppc	osdppc-rh71-01		~/dev/bld-scxcore	om
+host:	suse_10_32	osd-sls10-01		~/dev/bld-scxcore	om
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-scxcore	om
+
+#host:	centos_7_64_p	jc64-cent7x-01		~/dev/p-repos/bld-scxcore  om
+
+#
+# Apache Project
+#
+
+host:	suse_10_32	osd-sls10-01		~/dev/bld-apache	apache
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-apache	apache
+
+
+#
+# Configuration Manager
+#
+
+host:	aix_6.1		osd16-aix61-01		~/dev/bld-scxcm		cm
+host:	aix_7.1		osd16-aix71-01		~/dev/bld-scxcm		cm
+host:	hp_v3_ia64	osdevia-hpux31-01	~/dev/bld-scxcm		cm
+host:	sun_5.10_sparc	osdevsp-sol10-01	~/dev/bld-scxcm		cm
+host:	sun_5.10_x86	osd86-sol10-01		~/dev/bld-scxcm		cm
+host:	sun_5.11_sparc	osdevsp-sol11-02	~/dev/bld-scxcm		cm
+host:	sun_5.11_x86	osd86-sol11-01		~/dev/bld-scxcm		cm
+host:	suse_10_32	osd-sls10-01		~/dev/bld-scxcm		cm
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-scxcm		cm
+
+#
+# DSC Project
+#
+
+host:	suse_10_32	osd-sls10-01		~/dev/bld-dsc		dsc
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-dsc		dsc
+
+#
+# MySQL Project
+#
+
+host:	suse_10_32	osd-sls10-01		~/dev/bld-mysql		mysql
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-mysql		mysql
+
+#
+# OMS Project
+#
+
+host:	cent_5_32	osd-ct5-01		~/dev/bld-omsagent	oms
+host:	cent_5_64	osd64-ct5-01		~/dev/bld-omsagent      oms
+
+#
+# Docker Project
+#
+
+host:	suse_10_64	osd64-ub14-01		~/dev/bld-docker	docker
+
+#
+# OMI Project
+#
+
+host:	aix_6.1		osd16-aix61-01		~/dev/bld-omi		omi
+host:	aix_7.1		osd16-aix71-01		~/dev/bld-omi		omi
+host:	centos_5_32	osd-ct5-01		~/dev/bld-omi		omi
+host:	centos_5_64	osd64-ct5-01		~/dev/bld-omi		omi
+host:	centos_6_64	osd64-ct61-01		~/dev/bld-omi		omi
+host:	centos_7_64	osd64-ct7-01		~/dev/bld-omi		omi
+#host:	centos_7.3_64	osdev64-cent73-01	~/dev/bld-omi		omi
+#host:	debian_5_32	osd-deb5-01		~/dev/bld-omi		omi
+#host:	debian_5_64	osd64-deb5-01		~/dev/bld-omi		omi
+host:	hp_v3_ia64	osdevia-hpux31-01	~/dev/bld-omi		omi
+host:	mac_10.11	osd-mac1012-02		~/dev/bld-omi		omi
+host:	redhat_5_32	osd-rh5-01		~/dev/bld-omi		omi
+#host:	redhat_5_64	ostcdev64-rhel5-01	~/dev/bld-omi		omi
+host:	redhat_6_32	osd-rh6-01		~/dev/bld-omi		omi
+#host:	redhat_6_64	ostcdev64-rhel6-01	~/dev/bld-omi		omi
+host:	redhat_7_64	osd64-rh7-01		~/dev/bld-omi		omi
+host:	redhat_7.1_ppc	osdppc-rh71-01		~/dev/bld-omi		omi
+host:	sun_5.10_sparc	osdevsp-sol10-01	~/dev/bld-omi		omi
+host:	sun_5.10_x86	osd86-sol10-01		~/dev/bld-omi		omi
+host:	sun_5.11_sparc	osdevsp-sol11-02	~/dev/bld-omi		omi
+host:	sun_5.11_x86	osd86-sol11-01		~/dev/bld-omi		omi
+host:	suse_10_32	osd-sls10-01		~/dev/bld-omi		omi
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-omi		omi
+host:	suse_11_32	osd-sls11-01		~/dev/bld-omi		omi
+host:	suse_11_64	osd64-sls11-01		~/dev/bld-omi		omi
+#host:	suse_12_64	dev64-sles12-01		~/dev/bld-omi		omi
+host:	ubuntu_14_64	osd64-ub14-01		~/dev/bld-omi		omi
+host:	ubuntu_16_64	osd64-ub16-01		~/dev/bld-omi		omi
+host:	centos_7_64_p	jc64-cent7x-01		~/dev/p-repos/bld-omi	omi
+
+
+#
+# OMI Native Kits Project(Generate installation's nitive kits)
+#
+
+host:	aix_6.1		osd16-aix61-01		~/dev/bld-omi		omikits
+host:	aix_7.1		osd16-aix71-01		~/dev/bld-omi		omikits
+host:	hp_v3_ia64	osdevia-hpux31-01	~/dev/bld-omi		omikits
+host:	mac_10.11	osd-mac1012-02		~/dev/bld-omi		omikits
+host:	redhat_7.1_ppc	osdppc-rh71-01		~/dev/bld-omi		omikits
+host:	sun_5.10_sparc	osdevsp-sol10-01	~/dev/bld-omi		omikits
+host:	sun_5.10_x86	osd86-sol10-01		~/dev/bld-omi		omikits
+host:	sun_5.11_sparc	osdevsp-sol11-02	~/dev/bld-omi		omikits
+host:	sun_5.11_x86	osd86-sol11-01		~/dev/bld-omi		omikits
+host:	suse_10_32	osd-sls10-01		~/dev/bld-omi		omikits
+host:	suse_10_64	osd64-sls10-01		~/dev/bld-omi		omikits
+
+#
+# PAL Project
+#
+
+host:	centos_7_64_p	jc64-cent7x-01		~/dev/pal		pal

--- a/project.py
+++ b/project.py
@@ -22,7 +22,7 @@ class ProjectFactory:
     # Return true if a project is valid (false otherwise)
     #
     def Validate(self):
-        if self.project in ['apache', 'cm', 'docker', 'dsc', 'mysql', 'om', 'omi', 'oms', 'pal', 'psrp']:
+        if self.project in ['apache', 'cm', 'docker', 'dsc', 'mysql', 'om', 'omi', 'omikits', 'oms', 'pal', 'psrp']:
             return True
 
         return False
@@ -42,6 +42,8 @@ class ProjectFactory:
             return ProjectOM()
         elif self.project == 'omi':
             return ProjectOMI()
+        elif self.project == 'omikits':
+		    return ProjectOMIKITS()
         elif self.project == 'oms':
             return ProjectOMS()
         elif self.project == 'pal':
@@ -51,7 +53,6 @@ class ProjectFactory:
         else:
             # Whoops, this project hasn't been implemented
             raise NotImplementedError
-
 
 class Project:
     ##
@@ -129,11 +130,10 @@ class Project:
     #
     def GetPostBuildCommands(self):
         return self.postBuildSteps
-
+	
 ##
 # Project Definitions for each supported project
 #
-
 class ProjectApache(Project):
     ##
     # Ctor.
@@ -230,8 +230,22 @@ class ProjectOMI(Project):
         self.makeDependencies = False
         self.projectName = "omi"
         self.targets = "clean"  # Do 'make clean' just do something (regress is all inclusive)
-        self.postBuildSteps = [ "./regress" ]
+        self.postBuildSteps = ["./regress"]
 
+class ProjectOMIKITS(Project):
+    ##
+    # Ctor.
+    def __init__(self):
+        self.buildDirectory = "omi/Unix"
+        self.cloneSource = "git@github.com:Microsoft/Build-omi.git"
+        self.usesConfigureScript = True
+        self.configureQuals = "--enable-system-build --enable-native-kits"
+        self.subProjects = ["omi", "pal"]
+        self.makeDependencies = False
+        self.projectName = "omi"
+        self.targets = " "  # Do 'make clean' just do something (regress is all inclusive)
+        self.postBuildSteps = ["echo -n The OMI native kit is here: ; echo -n `hostname`; echo -n :; cd ./../Packages; pwd; echo;ls -R"]
+				
 class ProjectOMS(Project):
     ##
     # Ctor.


### PR DESCRIPTION
Add omikits project to support OMI private build generation.

===========Example log======================================
The OMI native kit is here:osd64-sls10-01:/home/johnliu/dev/bld-omi/omi/Packages

Linux_ULINUX_1.0_x64_64_Debug

./Linux_ULINUX_1.0_x64_64_Debug:
openssl_0.9.8
openssl_1.0.0
openssl_1.1.0

./Linux_ULINUX_1.0_x64_64_Debug/openssl_0.9.8:
libmi.so
omi-1.4.2-108.ssl_098.ulinux.x64.debug.deb
omi-1.4.2-108.ssl_098.ulinux.x64.debug.rpm

./Linux_ULINUX_1.0_x64_64_Debug/openssl_1.0.0:
libmi.so
omi-1.4.2-108.ssl_100.ulinux.x64.debug.deb
omi-1.4.2-108.ssl_100.ulinux.x64.debug.rpm

./Linux_ULINUX_1.0_x64_64_Debug/openssl_1.1.0:
libmi.so
omi-1.4.2-108.ssl_110.ulinux.x64.debug.deb
omi-1.4.2-108.ssl_110.ulinux.x64.debug.rpm
======================================================